### PR TITLE
Fix links in excelBPF™ eBee section

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ This eBeeDex lists all known eBees and their back story. If you find any more in
      <br />
      <br />
        Backstory:
-       excelBPF™ eBee is a technology futurist, expert Excel user, and a bit of a practical joker who plays light-hearted [April Fool's Day jokes](https://ebpf.io/blog/launching-excel-bpf/) on people.  She's super excited about the promise of [eBPF for Windows](https://github.com/microsoft/ebpf-for-windows) and wants to help the community think about what an eBPF empowered Windows experience would look like. Having fun by playing a joke with her Excel VBA skills is also in the books. 
+       excelBPF™ eBee is a technology futurist, expert Excel user, and a bit of a practical joker who plays light-hearted <a href="https://ebpf.io/blog/launching-excel-bpf">April Fool's Day jokes</a> on people.  She's super excited about the promise of <a href="https://github.com/microsoft/ebpf-for-windows">eBPF for Windows</a> and wants to help the community think about what an eBPF empowered Windows experience would look like. Having fun by playing a joke with her Excel VBA skills is also in the books.
    </td>
   </tr>
   <tr>


### PR DESCRIPTION
Markdown syntax cannot be used inside block-level HTML tags like `<table>`, see https://www.markdownguide.org/basic-syntax/#html-best-practices

This commit changes them to use HTML `<a>` links so they get rendered properly.

Before this change:

![image-before](https://user-images.githubusercontent.com/539708/232007196-3ea5bb41-c72f-4e89-8eae-0e9814859112.png)

After this change:

![image-after](https://user-images.githubusercontent.com/539708/232007047-fc697126-ca57-4a55-a4ff-1b4e85f2c6f8.png)

